### PR TITLE
delete this useless if-statement

### DIFF
--- a/test/texture.c
+++ b/test/texture.c
@@ -107,10 +107,6 @@ int main(int argc, char** argv) {
 	}
 
 	spoopy_texture_t* tex = test_renderer_load_texture("test/tung.png");
-	if(!tex) {
-		return 1;
-	}
-
 	spoopy_api_texture_set(pipeline, "tex0", "samp0", tex);
 	while(!spoopy_api_should_quit()) {
 		spoopy_events_poll(handler_ptr, 0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a null-validation check that prevented texture loading errors from causing downstream issues. Note: This change eliminates a safety mechanism; texture loading failures may now result in unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->